### PR TITLE
Refina layout e espaçamentos do portfólio

### DIFF
--- a/src/components/Cards/Wide.tsx
+++ b/src/components/Cards/Wide.tsx
@@ -30,7 +30,7 @@ export function WideCard({
 
   return (
     <div className="w-full lg:w-5/6" {...props}>
-      <div className="flex flex-col items-center flex-grow p-3 pb-6 border border-solid md:p-4 bg-card-gradient border-highlight-color rounded-2xl border-1 text-secondary-color md:text-left gap-x-6 md:flex-row">
+      <div className="group flex flex-col items-center gap-5 rounded-2xl border border-solid border-highlight-color bg-card-gradient p-4 pb-6 text-secondary-color transition duration-300 hover:-translate-y-0.5 hover:border-primary-color/50 hover:shadow-button md:flex-row md:items-stretch md:gap-6 md:p-5 md:text-left lg:p-6">
         {renderComponent != undefined ? (
           renderComponent({
             className: baseImgProps.className,
@@ -50,7 +50,7 @@ export function WideCard({
           />
         )}
 
-        <div className="max-sm:mt-2">{children}</div>
+        <div className="w-full max-sm:mt-2">{children}</div>
       </div>
     </div>
   );

--- a/src/components/Projects/index.tsx
+++ b/src/components/Projects/index.tsx
@@ -22,15 +22,15 @@ type ProjectsProps = {
 
 export function Projects({ list, labels }: ProjectsProps) {
   return (
-    <div className="flex flex-col items-center justify-around gap-4 mt-8 md:mt-16 md:gap-8">
+    <div className="mt-10 flex flex-col items-center justify-around gap-6 md:mt-14 md:gap-8">
       {list.map((project) => (
         <WideCard
           img={{ src: project.imgSrc, alt: project.title }}
           key={project.title}
           data-aos="fade-up"
         >
-          <div className="flex flex-col items-center md:items-start lg:items-center gap-y-2 gap-x-4 lg:flex-row">
-            <h3 className="mt-2 text-2xl font-bold text-white md:mt-0">
+          <div className="flex flex-col items-center gap-x-4 gap-y-3 md:items-start lg:flex-row lg:items-center">
+            <h3 className="text-2xl font-bold text-white">
               {project.title}
             </h3>
 
@@ -46,7 +46,7 @@ export function Projects({ list, labels }: ProjectsProps) {
             </div>
           </div>
 
-          <p className="px-2 mt-2 mb-4 text-base md:px-0">
+          <p className="mb-5 mt-2 text-base/7 text-secondary-color md:mb-6 md:px-0">
             {project.description}
           </p>
 

--- a/src/components/Section/index.tsx
+++ b/src/components/Section/index.tsx
@@ -11,10 +11,11 @@ export function Section({
   ...props
 }: SectionProps) {
   const classNames = {
-    hero: "relative flex flex-col-reverse items-center justify-center gap-10 px-6 pb-20 md:flex-row pt-36 md:px-16 md:gap-20",
+    hero: "relative mx-auto flex w-full max-w-[1200px] flex-col-reverse items-center justify-center gap-10 px-6 pb-20 pt-32 sm:gap-12 md:flex-row md:px-10 md:pb-24 md:pt-40 lg:gap-20 lg:px-16",
     featured:
-      "px-4 py-16 border-solid sm:px-6 md:px-20 bg-card-gradient border-y border-highlight-color",
-    simple: "text-center pt-16 px-4 sm:px-6 md:px-20 max-w-[1400px] mx-auto",
+      "mx-auto w-full border-y border-solid border-highlight-color bg-card-gradient px-4 py-16 sm:px-6 md:px-10 md:py-20 lg:px-16",
+    simple:
+      "mx-auto w-full max-w-[1200px] px-4 pt-20 text-center sm:px-6 md:px-10 md:pt-24 lg:px-16 lg:pt-28",
   };
 
   return (

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -40,7 +40,7 @@
   p,
   li,
   pre {
-    @apply text-base/7 md:text-lg/7 lg:text-xl/8;
+    @apply text-base/7 md:text-lg/8;
   }
 
   @media (min-width: 50em) {
@@ -53,7 +53,7 @@
   }
 
   .backgrounds {
-    /* min-height: 100%; */
+    min-height: 100%;
     isolation: isolate;
     background:
       /*footer*/
@@ -64,5 +64,9 @@
         no-repeat,
       /*center */ var(--bg-image-subtle) center/var(--bg-gradient-size)
         no-repeat;
+  }
+
+  section {
+    scroll-margin-top: 5.5rem;
   }
 }


### PR DESCRIPTION
## Resumo
- ajusta os presets de espaçamento dos `Section` para uma largura máxima mais consistente e respiro maior entre blocos
- moderniza o visual dos cards largos de projetos com hover sutil, padding melhor distribuído e alinhamento interno mais estável
- melhora tipografia de parágrafos para reduzir poluição visual em telas grandes
- adiciona `scroll-margin-top` para evitar que âncoras fiquem escondidas sob o navbar

## Arquivos alterados
- `src/components/Section/index.tsx`
- `src/components/Cards/Wide.tsx`
- `src/components/Projects/index.tsx`
- `src/styles/globals.css`

## Impacto esperado
- melhor hierarquia visual e ritmo de leitura
- layout mais moderno mantendo a paleta preto + azul/roxo
- navegação por âncoras mais confortável

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f6113463b0832b862c34a65eca357d)